### PR TITLE
Add template email & community thread post pre-workshop communication

### DIFF
--- a/comms/README.md
+++ b/comms/README.md
@@ -1,0 +1,12 @@
+# Pre-workshop communication
+
+Workshop participants need to complete some setup prior to a workshop, namely: 
+
+1. Have a recent version of R
+2. Have a recent version of RStudio
+3. Set up git and GitHub, connect to RStudio, and create a GitHub PAT
+
+To facilitate the pre-work, we send out an email at least 10 days in advance
+with instructions. We also create a thread on RStudio Community where people can
+get help if they need it. Templates for the email and Community post are in this
+folder.

--- a/comms/community.md
+++ b/comms/community.md
@@ -1,0 +1,18 @@
+This post describes pre-workshop setup necessary for the workshop:
+
+What They Forgot to Teach You About R
+at {LOCATION}
+{DATES}
+
+It's all about Git + GitHub + RStudio (the pre-workshop setup, that is).
+
+This truly requires your attention before the morning of {FIRST DAY}. We want to show you how to use Git/GitHub in your life as an R-using data analyst, which means we can't afford to get bogged down in a hot mess of Git installation issues. Let's try to work through them beforehand.
+
+Do what's listed here: https://happygitwithr.com/workshops.html#pre-workshop-set-up
+
+This is the thread to use if you need some help.
+
+If you wonder why I've chosen to include Git/GitHub in this workshop, you might want to read [Excuse me, do you have a moment to talk about version control?](https://peerj.com/preprints/3159v2/).
+
+Go forth and install Git! :boom:
+

--- a/comms/community.md
+++ b/comms/community.md
@@ -12,7 +12,7 @@ Do what's listed here: https://happygitwithr.com/workshops.html#pre-workshop-set
 
 This is the thread to use if you need some help.
 
-If you wonder why I've chosen to include Git/GitHub in this workshop, you might want to read [Excuse me, do you have a moment to talk about version control?](https://peerj.com/preprints/3159v2/).
+If you wonder why we've chosen to include Git/GitHub in this workshop, you might want to read [Excuse me, do you have a moment to talk about version control?](https://peerj.com/preprints/3159v2/).
 
 Go forth and install Git! :boom:
 

--- a/comms/email.md
+++ b/comms/email.md
@@ -1,0 +1,13 @@
+Hello everyone,
+
+We're looking forward to seeing you all at the What They Forgot to Teach You About R workshop at {LOCATION} on {DATES}. This email covers important setup that you'll need to do before the workshop.
+
+To fully participate in the workshop, you'll need to bring with you a laptop you can install R packages on and that has:
+
+1. A recent version of R (we recommend 3.6+)
+2. A recent version of RStudio (we recommend 1.2.5000+; versions earlier than 1.1 will _not_ work)
+3. Git and GitHub set up and connected to RStudio
+
+Instructions on the necessary git and GitHub setup are here: https://happygitwithr.com/workshops.html#pre-workshop-set-up. Completing this will take at least 1-2 hours, and really does need to be done before the workshop starts.
+
+We are happy to help if you run into any issues. Please post questions on {COMMUNITY THREAD} and one of us will get back to you there.

--- a/comms/email.md
+++ b/comms/email.md
@@ -6,8 +6,8 @@ To fully participate in the workshop, you'll need to bring with you a laptop you
 
 1. A recent version of R (we recommend 3.6+)
 2. A recent version of RStudio (we recommend 1.2.5000+; versions earlier than 1.1 will _not_ work)
-3. Git and GitHub set up and connected to RStudio
+3. Git and GitHub set up and connected to RStudio (including a GitHub personal access token)
 
 Instructions on the necessary git and GitHub setup are here: https://happygitwithr.com/workshops.html#pre-workshop-set-up. Completing this will take at least 1-2 hours, and really does need to be done before the workshop starts.
 
-We are happy to help if you run into any issues. Please post questions on {COMMUNITY THREAD} and one of us will get back to you there.
+We are happy to help if you run into any issues. Please post questions on {COMMUNITY THREAD} and one of us will get back to you there. We will also have TAs onsite who may be able to help during a break prior to the first git/GitHub session, but do not rely on that. We can't deal with many people or with very tricky issues in that setting. It is much better to complete the setup in advance.


### PR DESCRIPTION
Since communicating pre-work and setting up the Community thread are recurring steps to running a WTF workshop, I've put together templates with the relevant info. @jennybc does this look complete to you? Do we have any recommendations for people who don't have access to a laptop with sufficient permissions to install packages on the fly during the workshop?